### PR TITLE
Avoid GitHub API call when labels input is empty

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3537,7 +3537,7 @@ function getAndValidateArgs() {
             const args = {
                 githubToken: core.getInput('github_token', { required: true }),
                 labels: core
-                    .getInput('labels', { required: true })
+                    .getInput('labels')
                     .split('\n')
                     .filter(l => l !== ''),
                 owner: core.getInput('repo').split('/')[0],
@@ -5058,6 +5058,9 @@ class Processor {
     process() {
         return __awaiter(this, void 0, void 0, function* () {
             try {
+                if (this.options.labels.length === 0) {
+                    return;
+                }
                 let number = 0;
                 const payload = github.context.payload;
                 if (isWebhookPayloadPullRequest(payload)) {

--- a/src/Processor.ts
+++ b/src/Processor.ts
@@ -25,6 +25,10 @@ export class Processor {
 
   async process(): Promise<void> {
     try {
+      if (this.options.labels.length === 0) {
+        return;
+      }
+
       let number = 0;
       const payload = github.context.payload;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ async function getAndValidateArgs(): Promise<ProcessorOptions> {
       githubToken: core.getInput('github_token', { required: true }),
 
       labels: core
-        .getInput('labels', { required: true })
+        .getInput('labels')
         .split('\n')
         .filter(l => l !== ''),
 


### PR DESCRIPTION
The labels input is required, but if `''` is specified this action has an error when calling GitHub API.