### PR TITLE
Make github_token not requirement

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ const core = __importStar(__webpack_require__(393));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const githubToken = core.getInput('github_token', { required: true });
+            const githubToken = core.getInput('github_token');
             const labels = core
                 .getInput('labels')
                 .split('\n')

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core';
 
 async function run(): Promise<void> {
   try {
-    const githubToken = core.getInput('github_token', { required: true });
+    const githubToken = core.getInput('github_token');
 
     const labels = core
       .getInput('labels')


### PR DESCRIPTION
## What this PR does / Why we need it

The documentation says `github_token` is not required, but the following error occurred.

```
Error: Error: Input required and not supplied: github_token
Error: Input required and not supplied: github_token
```

## Which issue(s) this PR fixes

Fixes #258 