### PR TITLE
Add steps[*].name in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ jobs:
   add_label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-add-labels@v1
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: add label
+        uses: actions-ecosystem/action-add-labels@v1
         if: ${{ startsWith(github.event.comment.body, '/add-labels') }}
         with:
           labels: bug
@@ -57,8 +60,11 @@ jobs:
   add_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-ecosystem/action-add-labels@v1
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: add labels
+        uses: actions-ecosystem/action-add-labels@v1
         if: ${{ startsWith(github.event.comment.body, '/add-labels') }}
         with:
           labels: |


### PR DESCRIPTION

## What this PR does / Why we need it

Removes the first uses clause from the example Action code.

GitHub Actions only allows one `uses` clause, otherwise error `'uses' is already defined` will appear.

<img width="988" alt="image" src="https://user-images.githubusercontent.com/1985317/154345841-996994fe-0da8-40f2-b364-b98bbac8df01.png">

You only need to call this action by invoking the action fro *this* repo, you do not additionally need to invoke `actions/checkout@v2`

## Which issue(s) this PR fixes

It's possible that #333's complaint is resolved by this, but I don't know.
