### PR TITLE
Update to use Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: The number of the issue or pull request.
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: bookmark


### PR DESCRIPTION
## What this PR does / Why we need it
Once Node 12 will get deprecated, this action needs to run using Node 16

## Which issue(s) this PR fixes
Upgrades the Node version runner to version 16.

Fixes #
