### PR TITLE
Update Node 16 action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: The number of the issue or pull request.
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: bookmark


### PR DESCRIPTION
## What this PR does / Why we need it

Once Node 12 will get deprecated, this action needs to run using Node 16.
It will start failing on June 1st.

## Which issue(s) this PR fixes

Fixes #459

@micnncim I apologize for the inconvenience, but please review this update
